### PR TITLE
fix: remove react testing library from tech stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ npm run start
 -   TypeScript or JavaScript
 -   NPM
 -   Vite
--   React Testing Library
 -   ESLint, Prettier & CSpell
 -   Tailwind CSS
 -   Fontsource


### PR DESCRIPTION
React Testing Library was replaced by Cypress, for visual and more reliable component testing 